### PR TITLE
Remove deprecated build parameter ´-i

### DIFF
--- a/cmd/docker-machine-driver-kvm/Makefile
+++ b/cmd/docker-machine-driver-kvm/Makefile
@@ -1,4 +1,4 @@
 default: build
 
 build:
-	GOGC=off go build -i -o docker-machine-driver-kvm
+	GOGC=off go build -o docker-machine-driver-kvm


### PR DESCRIPTION
The build for docker-machine-kvm fails because go 1.20 and later versions have removed the deprecated -i parameter. The issue can be found in the file cmd/docker-machine-driver-kvm/Makefile and the parameter has been deprecated since go 1.10.

Please consider updating the Makefile to accommodate the changes in go 1.20+ and remove the deprecated -i parameter to avoid this issue in future builds.